### PR TITLE
Content-Length: handle body w/ UTF8 characters for Ruby 1.9+ to avoid Rack::Lint::LintError

### DIFF
--- a/lib/load_speed.rb
+++ b/lib/load_speed.rb
@@ -14,7 +14,10 @@ module Rack
         index = body.rindex("</body>")
         if index
           body.insert(index, performance_code)
-          headers["Content-Length"] = body.length.to_s
+          #
+          # handle body w/ UTF8 characters for Ruby 1.9+ to avoid Rack::Lint::LintError
+          #
+          headers["Content-Length"] = (body.respond_to?(:bytesize) ? body.bytesize : body.length).to_s
           response = [body]
         end
       end


### PR DESCRIPTION
Thanks to cloudhead/toto#93, I have uncovered why our **Rails** application that uses **stopwatch** was producing `Rack::Lint::LintError`s, _e.g._:

> ERROR -- : app error: Content-Length header was 48738, but should be 48748 (Rack::Lint::LintError)

This is a result of how Ruby handles lengths of UTF8 strings differently between 1.8 and 1.9.

This pull request uses `String#bytesize()` if `body` responds to it, otherwise falls back to `String#length` and eliminates these `Rack::Lint::LintError`s in our **Rails** app.

The **stopwatch** gem is very useful for **Rails** application development, and we have been using it for many years, thank you!