### PR TITLE
Rails 5, Railtie: resolve middleware warning by using class rather than string

### DIFF
--- a/lib/stopwatch/railtie.rb
+++ b/lib/stopwatch/railtie.rb
@@ -1,7 +1,7 @@
 module Stopwatch
   class Railtie < Rails::Railtie
     initializer "newplugin.initialize" do |app|
-      app.config.middleware.use "Rack::LoadSpeed"
+      app.config.middleware.use Rack::LoadSpeed
 
       # Start processing
       ActiveSupport::Notifications.subscribe "start_processing.action_controller" do |*args|


### PR DESCRIPTION
Greetings!

Minor fix here:

Use class, `Rack::LoadSpeed`, rather than string `"Rack::LoadSpeed"`, to resolve deprecation warning seen w/ Rails 5.0:

> DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change them to actual class references.  For example:
>
>  "Rack::LoadSpeed" => Rack::LoadSpeed

_viz._ https://github.com/rails/rails/commit/83b767ce

Thanks!